### PR TITLE
Add unpack algorithm optimized for CoW Filesystems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -343,8 +343,16 @@ CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder
 
 In this example the "**dll**" folder and everything below as well as the "**docs**" file or folder is excluded from unpack.
 
-```
 CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder -ft glob -ef dll/** -ef docs
+### Optimize unpack for Filesystems with Copy-On-Write
+
+Some Filesystems like Microsoft DevDrive (ReFS) or Btrfs support Copy-On-Write functionality.
+This allows copying files without taking up additional disk space. 
+With `-cow` you can specify that FastPack should optimize its extraction for this scenario.
+In this case identical files only take up disk space once reducing the required disk space for the extracted archive.
+
+```
+CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder -cow
 ```
 
 ### Do a dry-run of the unpack with simple text output

--- a/src/FastPack.Lib/Actions/UnpackAction.cs
+++ b/src/FastPack.Lib/Actions/UnpackAction.cs
@@ -24,15 +24,14 @@ public class UnpackAction : IAction
 
 	public async Task<int> Run()
 	{
-		await ValidateOptions();
+		ValidateOptions();
 
 		return await (await ArchiveUnpackerFactory.GetUnpacker(Options.InputFilePath, Logger)).Extract(Options.InputFilePath, Options);
 	}
 
-	private async Task ValidateOptions()
+	private void ValidateOptions()
 	{
 		Options.MaxDegreeOfParallelism ??= Environment.ProcessorCount;
-		Options.MaxMemory ??= (long)Math.Floor(await MemoryInfo.GetAvailableMemoryInBytes(Logger) * 0.8); // the default is 80% of the available memory
 
 		if (Options.OutputDirectoryPath == null)
 			throw new InvalidOptionException("Please provide the output directory path.", nameof(Options.OutputDirectoryPath), ErrorConstants.Unpack_OutputDirectoryPath_Missing);

--- a/src/FastPack.Lib/Compression/IFileCompressor.cs
+++ b/src/FastPack.Lib/Compression/IFileCompressor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -8,6 +9,7 @@ public interface IFileCompressor
 {
 	public Task DecompressFile(Stream sourceStream, Stream targetStream);
 	public Task<byte[]> DecompressFile(Stream sourceStream);
+	public Task DecompressFileChunked(Stream sourceStream, int chunkSize, Func<ReadOnlyMemory<byte>, ValueTask> callback);
 	public Task<Stream> CompressFile(string inputDirectory, string inputFile, ushort compressionLevel, Stream targetStream = null);
 	public ushort GetDefaultCompressionLevel();
 	public IDictionary<ushort, string> GetCompressionLevelValuesWithNames();

--- a/src/FastPack.Lib/Compression/NoCompressionFileCompressor.cs
+++ b/src/FastPack.Lib/Compression/NoCompressionFileCompressor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -20,6 +21,19 @@ public class NoCompressionFileCompressor : IFileCompressor
 		byte[] bytes = memoryStream.GetBuffer();
 		Array.Resize(ref bytes, (int)memoryStream.Length); // this is benchmarked in MemoryStreamGetBytesComparison
 		return bytes;
+	}
+	
+	public async Task DecompressFileChunked(Stream sourceStream, int chunkSize, Func<ReadOnlyMemory<byte>, ValueTask> callback)
+	{
+		using var memoryOwner = MemoryPool<byte>.Shared.Rent(chunkSize);
+		var slicedMemory = memoryOwner.Memory[..chunkSize];
+
+		while (true)
+		{
+			var readCount = await sourceStream.ReadAsync(slicedMemory);
+			if(readCount is 0) break;
+			await callback(slicedMemory[..readCount]);
+		}
 	}
 
 	public async Task<Stream> CompressFile(string inputDirectory, string inputFile, ushort compressionLevel, Stream targetStream = null)

--- a/src/FastPack.Lib/Options/UnpackOptions.cs
+++ b/src/FastPack.Lib/Options/UnpackOptions.cs
@@ -10,7 +10,6 @@ public class UnpackOptions : FilterOptions, IOptions
 	public string InputFilePath { get; set; }
 	public string OutputDirectoryPath { get; set; }
 	public int? MaxDegreeOfParallelism { get; set; }
-	public long? MaxMemory { get; set; }
 	public bool DryRun { get; set; }
 	public bool DetailedDryRun { get; set; }
 	public OutputFormat DryRunOutputFormat { get; set; }
@@ -24,4 +23,5 @@ public class UnpackOptions : FilterOptions, IOptions
 	public bool RestoreDates { get; set; } = true;
 	public bool RestorePermissions { get; set; } = true;
 	public bool IgnoreDiskSpaceCheck { get; set; }
+	public bool OptimizeForCopyOnWriteFilesystem { get; set; }
 }

--- a/src/FastPack.Lib/Unpackers/ArchiveUnpackerV1.cs
+++ b/src/FastPack.Lib/Unpackers/ArchiveUnpackerV1.cs
@@ -156,81 +156,99 @@ internal class ArchiveUnpackerV1 : Unpacker
 	private async Task UnpackFiles(UnpackOptions options, IEnumerable<ManifestEntry> manifestEntries, Manifest manifest, string inputFile)
 	{
 		IFileCompressor fileCompressor = FileCompressorFactory.GetCompressor(manifest.CompressionAlgorithm);
-
-		// we order descending here, because a large file at first will fully occupy the consumer (sequential file write)
-		List<ManifestEntry> allFileEntries = manifestEntries.Where(x => x.Type == EntryType.File).OrderByDescending(x => x.OriginalSize).ToList();
-
-		// Math.Min(options.MaxMemory ?? 0, int.MaxValue) is used to force all files larger than 2 GB to be processed sequentially - Otherwise the MemoryStream would crash
-		List<ManifestEntry> parallelFileEntries = allFileEntries.Where(e => e.OriginalSize <= Math.Min(options.MaxMemory ?? 0, int.MaxValue)).ToList();
-		List<ManifestEntry> sequentialFileEntries = allFileEntries.Where(e => e.OriginalSize > Math.Min(options.MaxMemory ?? 0, int.MaxValue)).ToList();
-
+		
+		List<ManifestEntry> allFileEntries = manifestEntries.Where(x => x.Type == EntryType.File).ToList();
+		
 		int filesProcessed = 0;
-		IProgress<int> unpackProgress = new Progress<int>(current => ShowProgress(current, allFileEntries.Sum(e => e.FileSystemEntries.Count), "Unpack progress: ").Wait());
-		// process parallel entries
-		await LimitParallelProducerConsumer.ProcessData(parallelFileEntries,
-			async manifestEntry => {
-				SharedUnpackWorkItemState sharedUnpackWorkItemState = new() {
-					WorkItemReferences = manifestEntry.FileSystemEntries.Count
-				};
-				IEnumerable<UnpackWorkItem> unpackWorkItems = manifestEntry.FileSystemEntries.ConvertAll(x => new UnpackWorkItem
-				{
-					ManifestFileSystemEntry = x,
-					SharedState = sharedUnpackWorkItemState
-				});
-				await ReadFromDataStream(inputFile, manifestEntry, async decompressionStream => sharedUnpackWorkItemState.UnpackedData = await fileCompressor.DecompressFile(decompressionStream));
-				return unpackWorkItems;
-			},
-			async unpackWorkItem => {
-				string targetFile = Path.Combine(options.OutputDirectoryPath, unpackWorkItem.ManifestFileSystemEntry.RelativePath);
-				await using (FileStream fileStream = new(targetFile, FileMode.Create, FileAccess.Write, FileShare.None, Constants.BufferSize, Constants.OpenFileStreamsAsync))
-					fileStream.Write(unpackWorkItem.SharedState.UnpackedData, 0, unpackWorkItem.SharedState.UnpackedData.Length);
-					
-				SetMetadata(manifest, targetFile, unpackWorkItem.ManifestFileSystemEntry, options);
+		IProgress<int> unpackProgress = new Progress<int>(current => ShowProgress(current, allFileEntries.Count, "Unpack progress: ").Wait());
 
-				lock (unpackWorkItem.SharedState)
-				{
-					unpackWorkItem.SharedState.WorkItemReferences -= 1;
-				}
+		await Parallel.ForEachAsync(allFileEntries, new ParallelOptions {
+				MaxDegreeOfParallelism = options.MaxDegreeOfParallelism.Value
+		}, async (fileEntry, _) => {
+			if (options.OptimizeForCopyOnWriteFilesystem)
+				await DecompressManifestEntryCow(options, fileEntry, manifest, inputFile, fileCompressor);
+			else
+				await DecompressManifestEntry(options, fileEntry, manifest, inputFile, fileCompressor);
 
-				if (unpackWorkItem.SharedState.WorkItemReferences == 0)
-				{
-					// free memory
-					unpackWorkItem.SharedState.UnpackedData = null;
-				}
+			if (!options.ShowProgress)
+				return;
 
-				if (!options.ShowProgress)
-					return;
+			Interlocked.Increment(ref filesProcessed);
+			unpackProgress.Report(filesProcessed);
+		});
+	}
 
-				Interlocked.Increment(ref filesProcessed);
-				unpackProgress.Report(filesProcessed);
-			},
-			(items, current) => {
-				long currentSize = items.DistinctBy(x => x.Hash).Sum(x => x.OriginalSize);
-				return currentSize + current.OriginalSize <= options.MaxMemory;
-			},
-			source => source.FileSystemEntries.Select(x => x.RelativePath),
-			produced => produced.ManifestFileSystemEntry.RelativePath,
-			options.MaxDegreeOfParallelism!.Value,
-			options.MaxDegreeOfParallelism!.Value);
-
-		// process sequential entries
-		foreach (ManifestEntry manifestEntry in sequentialFileEntries)
+	private static async Task<FileStream[]> OpenFileStreams(IEnumerable<ManifestFileSystemEntry> entries, UnpackOptions options)
+	{
+		// Open FileStreams for every file. If opening of one file fails we need to dispose the files that were 
+		// already opened successfully.
+		List<FileStream> openedStreams = new();
+		try
 		{
-			foreach (ManifestFileSystemEntry manifestFileSystemEntry in manifestEntry.FileSystemEntries)
+			foreach (var entry in entries)
 			{
-				string targetFile = Path.Combine(options.OutputDirectoryPath, manifestFileSystemEntry.RelativePath);
-				await using (FileStream fileStream = new(targetFile, FileMode.Create, FileAccess.Write, FileShare.None, Constants.BufferSize, Constants.OpenFileStreamsAsync))
-					await ReadFromDataStream(inputFile, manifestEntry, async decompressionStream => await fileCompressor.DecompressFile(decompressionStream, fileStream));
-
-				SetMetadata(manifest, targetFile, manifestFileSystemEntry, options);
-
-				if (!options.ShowProgress)
-					continue;
-
-				Interlocked.Increment(ref filesProcessed);
-				unpackProgress.Report(filesProcessed);
+				var path = Path.Combine(options.OutputDirectoryPath, entry.RelativePath);
+				openedStreams.Add(File.Open(path, FileMode.Create, FileAccess.Write));
 			}
 		}
+		catch
+		{
+			foreach (var openedStream in openedStreams)
+			{
+				await openedStream.DisposeAsync();
+			}
+			throw;
+		}
+		return openedStreams.ToArray();
+	}
+	
+	private async Task DecompressManifestEntry(UnpackOptions options, ManifestEntry manifestEntry, Manifest manifest,
+			string inputFile, IFileCompressor fileCompressor)
+	{
+		var fileStreams = await OpenFileStreams(manifestEntry.FileSystemEntries, options);
+		try
+		{
+			const int decompressionChunkSize = 2 * 1024 * 1024;
+			await ReadFromDataStream(inputFile, manifestEntry, async decompressionStream =>
+					await fileCompressor.DecompressFileChunked(decompressionStream, decompressionChunkSize,
+							async (memory) => {
+								foreach (var fileStream in fileStreams)
+								{
+									await fileStream.WriteAsync(memory);
+								}
+							}));
+
+			foreach (var entry in manifestEntry.FileSystemEntries)
+			{
+				string path = Path.Combine(options.OutputDirectoryPath, entry.RelativePath);
+				SetMetadata(manifest, path, entry, options);
+			}
+		}
+		finally
+		{
+			foreach (var fileStream in fileStreams)
+			{
+				await fileStream.DisposeAsync();
+			}
+		}
+	}
+
+	private async Task DecompressManifestEntryCow(UnpackOptions options, ManifestEntry manifestEntry, Manifest manifest,
+			string inputFile, IFileCompressor fileCompressor)
+	{
+		ManifestFileSystemEntry firstEntry = manifestEntry.FileSystemEntries.First();
+
+		string firstTargetFile = Path.Combine(options.OutputDirectoryPath, firstEntry.RelativePath);
+		await using (FileStream fileStream = new(firstTargetFile, FileMode.Create, FileAccess.Write, FileShare.None, Constants.BufferSize, Constants.OpenFileStreamsAsync))
+			await ReadFromDataStream(inputFile, manifestEntry, async decompressionStream => await fileCompressor.DecompressFile(decompressionStream, fileStream));
+
+		foreach (ManifestFileSystemEntry entry in manifestEntry.FileSystemEntries.Skip(1))
+		{
+			string nextTargetFile = Path.Combine(options.OutputDirectoryPath, entry.RelativePath);
+			File.Copy(firstTargetFile, nextTargetFile, true);
+			SetMetadata(manifest, nextTargetFile, entry, options);
+		}
+		SetMetadata(manifest, firstTargetFile, firstEntry, options);
 	}
 
 	private async Task ShowProgress(int current, int total, string prefixText)

--- a/src/FastPack.Tests/FastPack.Lib/Actions/UnpackActionTests.cs
+++ b/src/FastPack.Tests/FastPack.Lib/Actions/UnpackActionTests.cs
@@ -217,26 +217,7 @@ namespace FastPack.Tests.FastPack.Lib.Actions
 				options.MaxDegreeOfParallelism.Should().Be(Environment.ProcessorCount);
 			}
 		}
-
-		[Test]
-		public async Task Ensure_MaxMemory_Is_Not_Changed_If_Not_Null()
-		{
-			// arrange
-			UnpackOptions options = new() {
-				MaxMemory = 1234,
-			};
-			UnpackAction action = new(Mock.Of<ILogger>(), options);
-
-			try
-			{
-				await action.Run();
-			}
-			catch
-			{
-				options.MaxMemory.Should().Be(1234);
-			}
-		}
-
+		
 		[Test]
 		public async Task Ensure_MaxMemory_Is_Set_To_NonNull_If_Null()
 		{

--- a/src/FastPack.Tests/FastPack.Lib/Unpackers/ArchiveUnpackerV1Tests.cs
+++ b/src/FastPack.Tests/FastPack.Lib/Unpackers/ArchiveUnpackerV1Tests.cs
@@ -15,12 +15,25 @@ using FastPack.TestFramework.Common;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using System.Collections;
 
 namespace FastPack.Tests.FastPack.Lib.Unpackers;
 
 [TestFixture]
 internal class ArchiveUnpackerV1Tests
 {
+	private class UnpackOptionsTestData
+	{
+		public static IEnumerable TestCases
+		{
+			get
+			{
+				yield return new TestCaseData(true);
+				yield return new TestCaseData(false);
+			}
+		}
+	}
+	
 	[Test]
 	public async Task Ensure_GetManifestFromStream_Works()
 	{
@@ -46,7 +59,8 @@ internal class ArchiveUnpackerV1Tests
 	}
 
 	[Test]
-	public async Task Ensure_Extract_TestCase1_Works()
+	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
+	public async Task Ensure_Extract_TestCase1_Works(bool optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();
@@ -60,7 +74,7 @@ internal class ArchiveUnpackerV1Tests
 		((ArchiveUnpackerV1)unpacker).FileCompressorFactory = fileCompressorFactoryMock.Object;
 
 		// act
-		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 4, MaxMemory = 1024 * 1024 * 1024, ShowProgress = false });
+		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 4, ShowProgress = false, OptimizeForCopyOnWriteFilesystem = optimizeForCopyOnWriteFilesystem});
 
 		// assert
 		extract.Should().Be(0);
@@ -75,7 +89,8 @@ internal class ArchiveUnpackerV1Tests
 	}
 
 	[Test]
-	public async Task Ensure_Extract_TestCase2_Works()
+	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
+	public async Task Ensure_Extract_TestCase2_Works(bool optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();
@@ -86,7 +101,7 @@ internal class ArchiveUnpackerV1Tests
 		IUnpacker unpacker = new ArchiveUnpackerV1(loggerMock.Object);
 
 		// act
-		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 4, MaxMemory = 100 });
+		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 4, OptimizeForCopyOnWriteFilesystem = optimizeForCopyOnWriteFilesystem});
 
 		// assert
 		extract.Should().Be(0);
@@ -106,7 +121,8 @@ internal class ArchiveUnpackerV1Tests
 	}
 
 	[Test]
-	public async Task Ensure_Extract_TestCase3_Works()
+	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
+	public async Task Ensure_Extract_TestCase3_Works(bool optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();
@@ -117,7 +133,7 @@ internal class ArchiveUnpackerV1Tests
 		IUnpacker unpacker = new ArchiveUnpackerV1(loggerMock.Object);
 
 		// act
-		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 1, MaxMemory = 1024*1024, ShowProgress = false });
+		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 1, ShowProgress = false, OptimizeForCopyOnWriteFilesystem = optimizeForCopyOnWriteFilesystem});
 
 		// assert
 		extract.Should().Be(0);
@@ -203,7 +219,7 @@ internal class ArchiveUnpackerV1Tests
 		((Unpacker)unpacker).Filter = filterMock.Object;
 
 		// act
-		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 1, MaxMemory = 1024 * 1024, ShowProgress = false, IncludeFilters = { "subDir" }, ExcludeFilters = { "**/biggestFile.txt" } });
+		int extract = await unpacker.Extract(filePath, new UnpackOptions { OutputDirectoryPath = outputDirectory, MaxDegreeOfParallelism = 1, ShowProgress = false, IncludeFilters = { "subDir" }, ExcludeFilters = { "**/biggestFile.txt" } });
 
 		// assert
 		extract.Should().Be(0);

--- a/src/FastPack.Tests/FastPack/Options/Parsers/UnpackOptionsParserTests.cs
+++ b/src/FastPack.Tests/FastPack/Options/Parsers/UnpackOptionsParserTests.cs
@@ -145,48 +145,6 @@ public class UnpackOptionsParserTests : OptionsParserTestBase<UnpackOptionsParse
 			StrictMode = strictMode
 		};
 
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "-mm", "1G" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024*1024*1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "-mm", "1gb" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024 * 1024 * 1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "--maxmemory", "1M" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024 * 1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "--maxmemory", "1mb" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024 * 1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "-mm", "1K" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "-mm", "1kb" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 1024 },
-			StrictMode = strictMode
-		};
-
-		yield return new OptionsParserTestCaseData<UnpackOptions> {
-			Args = new[] { "-mm", "500" },
-			ExpectedOptions = new UnpackOptions { MaxMemory = 500 },
-			StrictMode = strictMode
-		};
-
 		// can not test negative values for max memory here, because calculating the expected memory is not exact. The memory changes between the call and the calculation
 
 		yield return new OptionsParserTestCaseData<UnpackOptions> {


### PR DESCRIPTION
There is now an option to choose between extraction for CoW filesystems and those without.
The Algorithm for Non-CoW filesystems was adjusted to use a constant amount of memory. The parameter specifiying the maximum memory was removed for unpack but is still accepted (and ignored) for compatibility reasons.