### PR TITLE
Automatically detect if unpack should optimize for copy-on-write filesystems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -344,16 +344,6 @@ CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder
 In this example the "**dll**" folder and everything below as well as the "**docs**" file or folder is excluded from unpack.
 
 CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder -ft glob -ef dll/** -ef docs
-### Optimize unpack for Filesystems with Copy-On-Write
-
-Some Filesystems like Microsoft DevDrive (ReFS) or Btrfs support Copy-On-Write functionality.
-This allows copying files without taking up additional disk space. 
-With `-cow` you can specify that FastPack should optimize its extraction for this scenario.
-In this case identical files only take up disk space once reducing the required disk space for the extracted archive.
-
-```
-CMD> FastPack -a unpack -i C:\InputFile.fup -o C:\TargetFolder -cow
-```
 
 ### Do a dry-run of the unpack with simple text output
 

--- a/src/FastPack.Lib/CopyOnWriteDiskInfo.cs
+++ b/src/FastPack.Lib/CopyOnWriteDiskInfo.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace FastPack.Lib
+{
+	public static class CopyOnWriteDiskInfo
+	{
+		/// <summary>
+		/// Decision for this list: ReFS + Linux file systems
+		/// For linux filesystems:
+		/// - .NET runtime calls FICLONE: https://github.com/dotnet/runtime/blob/2a47838c6d353b783ca8466e40d7db756f2d2acf/src/native/libs/System.Native/pal_io.c#L1422
+		/// - According to Kernel docs this calls remap_file_range internally: https://www.kernel.org/doc/Documentation/filesystems/vfs.txt
+		/// - remap_file_range is implemented in the file systems listed here. To find this search remap_file_range on kernel source
+		/// - It was assumed that DriveInfo.DriveFormat returns the same string as the directory name in the kernel source
+		/// </summary>
+		private static readonly string[] FilesystemsWithCopyOnWrite = {
+				"refs",
+				"bcachefs",
+				"btrfs",
+				"nfs",
+				"ocfs2",
+				"overlayfs",
+				"smb",
+				"xfs"
+		};
+
+		public static bool DirectorySupportsCopyOnWrite(string directory)
+		{
+			var driveInfo = new DriveInfo(directory);
+			return driveInfo.IsReady && FilesystemsWithCopyOnWrite.Contains(driveInfo.DriveFormat, StringComparer.OrdinalIgnoreCase);
+		}
+	}
+}

--- a/src/FastPack.Lib/CopyOnWriteDiskInfo.cs
+++ b/src/FastPack.Lib/CopyOnWriteDiskInfo.cs
@@ -27,8 +27,17 @@ namespace FastPack.Lib
 
 		public static bool DirectorySupportsCopyOnWrite(string directory)
 		{
-			var driveInfo = new DriveInfo(directory);
-			return driveInfo.IsReady && FilesystemsWithCopyOnWrite.Contains(driveInfo.DriveFormat, StringComparer.OrdinalIgnoreCase);
+			try
+			{
+				var driveInfo = new DriveInfo(directory);
+				return driveInfo.IsReady &&
+						FilesystemsWithCopyOnWrite.Contains(driveInfo.DriveFormat, StringComparer.OrdinalIgnoreCase);
+			}
+			catch(ArgumentException)
+			{
+				// DriveInfo might fail if UNC paths are used. In that case we are going to assume that no CoW is supported.
+				return false;
+			}
 		}
 	}
 }

--- a/src/FastPack.Lib/OptimizeForCopyOnWriteFilesystem.cs
+++ b/src/FastPack.Lib/OptimizeForCopyOnWriteFilesystem.cs
@@ -1,0 +1,9 @@
+namespace FastPack.Lib
+{
+	public enum OptimizeForCopyOnWriteFilesystem
+	{
+		Auto,
+		On,
+		Off
+	}
+}

--- a/src/FastPack.Lib/Options/UnpackOptions.cs
+++ b/src/FastPack.Lib/Options/UnpackOptions.cs
@@ -23,5 +23,5 @@ public class UnpackOptions : FilterOptions, IOptions
 	public bool RestoreDates { get; set; } = true;
 	public bool RestorePermissions { get; set; } = true;
 	public bool IgnoreDiskSpaceCheck { get; set; }
-	public bool OptimizeForCopyOnWriteFilesystem { get; set; }
+	public OptimizeForCopyOnWriteFilesystem OptimizeForCopyOnWriteFilesystem { get; set; }
 }

--- a/src/FastPack.Lib/Unpackers/ArchiveUnpackerV1.cs
+++ b/src/FastPack.Lib/Unpackers/ArchiveUnpackerV1.cs
@@ -42,6 +42,11 @@ internal class ArchiveUnpackerV1 : Unpacker
 		Stopwatch overallStopWatch = Stopwatch.StartNew();
 		Stopwatch currentStopwatch = Stopwatch.StartNew();
 		
+		// Beware: Create output directory before checking CoW support because on Linux the folder must already exist 
+		// to be able to retrieve its volume.
+		if (!Directory.Exists(options.OutputDirectoryPath))
+			Directory.CreateDirectory(options.OutputDirectoryPath);
+
 		bool isCopyOnWriteEnabled = IsCopyOnWriteEnabled(options);
 
 		await Logger.InfoLine($"Using {options.MaxDegreeOfParallelism} of {Environment.ProcessorCount} logical cores.");
@@ -51,9 +56,6 @@ internal class ArchiveUnpackerV1 : Unpacker
 		await Logger.StartTextProgress("Reading manifest ...");
 		Manifest manifest = await GetManifestFromFile(inputFile);
 		await Logger.FinishTextProgress($"Got manifest in {currentStopwatch.Elapsed}.");
-
-		if (!Directory.Exists(options.OutputDirectoryPath))
-			Directory.CreateDirectory(options.OutputDirectoryPath);
 
 		currentStopwatch.Restart();
 		await Logger.StartTextProgress("Filtering files and directories to extract...");

--- a/src/FastPack.Tests/FastPack.Lib/Unpackers/ArchiveUnpackerV1Tests.cs
+++ b/src/FastPack.Tests/FastPack.Lib/Unpackers/ArchiveUnpackerV1Tests.cs
@@ -28,8 +28,8 @@ internal class ArchiveUnpackerV1Tests
 		{
 			get
 			{
-				yield return new TestCaseData(true);
-				yield return new TestCaseData(false);
+				yield return new TestCaseData(OptimizeForCopyOnWriteFilesystem.On);
+				yield return new TestCaseData(OptimizeForCopyOnWriteFilesystem.Off);
 			}
 		}
 	}
@@ -60,7 +60,7 @@ internal class ArchiveUnpackerV1Tests
 
 	[Test]
 	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
-	public async Task Ensure_Extract_TestCase1_Works(bool optimizeForCopyOnWriteFilesystem)
+	public async Task Ensure_Extract_TestCase1_Works(OptimizeForCopyOnWriteFilesystem optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();
@@ -90,7 +90,7 @@ internal class ArchiveUnpackerV1Tests
 
 	[Test]
 	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
-	public async Task Ensure_Extract_TestCase2_Works(bool optimizeForCopyOnWriteFilesystem)
+	public async Task Ensure_Extract_TestCase2_Works(OptimizeForCopyOnWriteFilesystem optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();
@@ -122,7 +122,7 @@ internal class ArchiveUnpackerV1Tests
 
 	[Test]
 	[TestCaseSource(typeof(UnpackOptionsTestData), nameof(UnpackOptionsTestData.TestCases))]
-	public async Task Ensure_Extract_TestCase3_Works(bool optimizeForCopyOnWriteFilesystem)
+	public async Task Ensure_Extract_TestCase3_Works(OptimizeForCopyOnWriteFilesystem optimizeForCopyOnWriteFilesystem)
 	{
 		// arrange
 		Mock<ILogger> loggerMock = new Mock<ILogger>();

--- a/src/FastPack/Options/Parsers/UnpackOptionsParser.cs
+++ b/src/FastPack/Options/Parsers/UnpackOptionsParser.cs
@@ -79,10 +79,11 @@ public class UnpackOptionsParser : IOptionsParser
 		await Logger.InfoLine("  -cow|--copy-on-write");
 		await Logger.InfoLine("    Optimize extraction for filesystems that support copy on write (e.g. ReFS/Microsoft DevDrive/Btrfs).");
 		await Logger.InfoLine("    Identical files will only take up disk space once but changes to one of them are still independent from copies.");
-		await Logger.InfoLine("    On Windows this requires Windows 11 24H2 or Windows Server 2025");
-		await Logger.InfoLine("    Default: Not active (Minimize IO for best performance on traditional file systems)");
+		await Logger.InfoLine("    On Windows this requires Windows 11 24H2 or Windows Server 2025 to work correctly");
+		await Logger.InfoLine("    Valid values: auto, on, off");
 		await Logger.InfoLine("    Required: false");
-		await Logger.InfoLine("    Example: -cow");
+		await Logger.InfoLine("    Default: auto");
+		await Logger.InfoLine("    Example: -cow off");
 		await Logger.InfoLine();
 		await Logger.InfoLine("  -dr|--dryrun [detailed]");
 		await Logger.InfoLine("    Only perform the action as dry run meaning no files will be written and only information about the actions will be returned.");
@@ -180,7 +181,7 @@ public class UnpackOptionsParser : IOptionsParser
 		parameterProcessingMap.AddMultiple(new[] { "-nd", "--no-dates" }, _ => { options.RestoreDates = false; return Task.FromResult(true); });
 		parameterProcessingMap.AddMultiple(new[] { "-nfp", "--no-permissions" }, _ => { options.RestorePermissions = false; return Task.FromResult(true); });
 		parameterProcessingMap.AddMultiple(new[] { "-isc", "--ignore-space-check" }, _ => Task.FromResult(options.IgnoreDiskSpaceCheck = true));
-		parameterProcessingMap.AddMultiple(new[] { "-cow", "--copy-on-write" }, _ => Task.FromResult(options.OptimizeForCopyOnWriteFilesystem = true));
+		parameterProcessingMap.AddMultiple(new[] { "-cow", "--copy-on-write" }, async _ => await argumentsParser.ProcessEnumParameterValue<OptimizeForCopyOnWriteFilesystem>(v => options.OptimizeForCopyOnWriteFilesystem = v));
 
 		return await argumentsParser.Parse(parameterProcessingMap) ? options : null;
 	}


### PR DESCRIPTION
This doesnt actually check if copyOnWrite is supported but instead checks based on the filesystem. Checking the actual support would involve lots of native interop. Instead a fixed list of file systems which support CoW was introduced.

With a CLI parameter the behaviour can be set to autodetection or forced on or off.

A new log message was added so that the user can easily tell which algorithm is used. This allows the user to see if the autodetection is working for him.